### PR TITLE
Placeholder PR for Sensitive Backend Configuration Disclosure – Issue #40

### DIFF
--- a/security/eMKayRa0/backend-config-disclosure-issue#40.txt
+++ b/security/eMKayRa0/backend-config-disclosure-issue#40.txt
@@ -1,0 +1,1 @@
+This placeholder relates to Issue #40: Sensitive backend configuration disclosure via the /api/masterdata endpoint. The API leaks wallet identifiers, roadmap plans, and internal logic without authentication.


### PR DESCRIPTION
Fix: Placeholder for backend config disclosure via /api/masterdata (issue #40)

This pull request serves as a placeholder for **Issue #40**, concerning the exposure of sensitive configuration via the public `/api/masterdata` endpoint.

### ⚠️ Description
The endpoint reveals:
- Wallet identifiers
- Internal referral and redemption logic
- Strategic roadmap plans
- Full terms and disclaimers in HTML
- Versioning and monetization details

### 🧪 Impact
- Targeted wallet phishing
- Unintended disclosure of strategic announcements
- Reputation and compliance risks

This placeholder file is submitted per the repository’s contribution policy requiring a PR for every issue.

Looking forward to feedback from maintainers.


git add security/placeholders/backend-config-disclosure-issue#40.txt git commit -m "Fix: Placeholder for backend config disclosure via /api/masterdata (Issue #40)" git push origin placeholder/backend-config-disclosure-issue#40