### PR TITLE
Fix: Placeholder commit for exposed printenv.pl CGI script on tb.aixblock.io (Issue #34)

### DIFF
--- a/security/eMKayRa0/cgi-disclosure-tb-aixblock-issue#34.txt
+++ b/security/eMKayRa0/cgi-disclosure-tb-aixblock-issue#34.txt
@@ -1,0 +1,1 @@
+This file serves as a placeholder for Issue #34, which reports an environment information disclosure via the publicly accessible CGI script printenv.pl on tb.aixblock.io.


### PR DESCRIPTION
Placeholder PR for Environment Disclosure via CGI Script on tb.aixblock.io – Issue #34
This pull request adds a placeholder file for **Issue #34**, which identifies an information disclosure vulnerability via an exposed CGI script at:

https://tb.aixblock.io/cgi-bin/printenv.pl


---

### ⚠️ Vulnerability Summary

The exposed `printenv.pl` CGI script leaks critical internal environment data:

- File paths (e.g., `E:/xampp/cgi-bin/`, `C:\Windows\system32`)
- System environment variables
- Installed software and versions (Apache/2.4.58, PHP/8.0.30, OpenSSL/3.1.3)
- Binary paths and dev tools (Python, Vulkan SDK, GTK3, PowerShell)
- Database config paths (e.g., `MYSQL_HOME`, `PHPRC`, `OPENSSL_CONF`)

---

### 🎯 Security Risks

| Attack Vector        | Risk Impact                                                                 |
|----------------------|------------------------------------------------------------------------------|
| LFI/Traversal        | Exposed file paths can assist in file inclusion or path traversal attacks.  |
| RCE/Command Injection| Insight into available executables (via PATH and COMSPEC).                  |
| Exploit Matching     | Apache, PHP, and OpenSSL version info aids in finding known vulnerabilities |
| Recon/Profiling      | Helps attackers fingerprint the server for tailored exploitation strategies |

---

### 🔐 Recommendations

- Immediately remove the `printenv.pl` script from **all environments**.
- Restrict `/cgi-bin/` via `.htaccess`, Apache configs, or WAF.
- Disable CGI modules unless explicitly required.
- Audit all server directories for similar debug/testing scripts.
- Monitor access logs for reconnaissance behavior on CGI endpoints.


### 🧮 CVSS Score

**CVSS v3.1 Base Score:** `5.3 (Medium)`  
**Vector:** `AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N`
