### PR TITLE
Fix: Placeholder for public pprof exposure on storage.aixblock.io (Issue #39)

### DIFF
--- a/security/eMKayRa0/storage-pprof-exposure-aixblock-issue#39.txt
+++ b/security/eMKayRa0/storage-pprof-exposure-aixblock-issue#39.txt
@@ -1,0 +1,1 @@
+This placeholder file corresponds to Issue #39, which reports an unauthenticated and publicly exposed Go pprof debug interface at http://storage.aixblock.io:9091/debug/pprof/.


### PR DESCRIPTION
Placeholder PR for CVE-2019-11248 – Exposed Go pprof Interface on storage.aixblock.io – Issue #39
his pull request introduces a placeholder file for **Issue #39**, reporting a high-severity vulnerability tied to the public exposure of Go's pprof debug interface on:

http://storage.aixblock.io:9091/debug/pprof/


---

### 🔍 Vulnerability Overview

The endpoint exposes full access to Go’s `net/http/pprof` profiler, including:

- `/heap` – Memory allocations
- `/goroutine` – Stack traces of all goroutines
- `/profile` – CPU profiling
- `/trace` – Execution trace capture

This violates secure deployment standards, as these interfaces are intended for **internal use only**, and exposure allows attackers to:

- 📤 Exfiltrate internal server data (goroutines, memory)
- ⚙️ Profile server behavior in real time
- 🔥 Initiate CPU- and memory-intensive operations (DoS risk)

---

### 🛡️ CVE Details

- **CVE**: [CVE-2019-11248](https://nvd.nist.gov/vuln/detail/CVE-2019-11248)
- **CWE**: CWE-200 – Exposure of Sensitive Information to an Unauthorized Actor
- **CVSS v3.1**: **7.5 (High)**  
  `AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H`

---

### 🧪 Steps to Reproduce

```bash
curl http://storage.aixblock.io:9091/debug/pprof/

# Then visit:
http://storage.aixblock.io:9091/debug/pprof/heap
http://storage.aixblock.io:9091/debug/pprof/goroutine
http://storage.aixblock.io:9091/debug/pprof/profile?seconds=30
http://storage.aixblock.io:9091/debug/pprof/trace?seconds=5

🖼️ Screenshots & Sample Output
/debug/pprof/goroutine

goroutine profile: total 9
1 @ 0x40f29f 0x40e17b 0x40e1e0 0x43ad6c ...

/debug/pprof/heap

# runtime.MemStats
Alloc = 3784552
TotalAlloc = 4827480
Sys = 19462016
NumGC = 4
...

🔥 Impact Analysis
Risk	Description
🧠 Information Exposure	Reveals stack traces, memory stats, goroutine internals
🧭 Reconnaissance Vector	Useful for attacker fingerprinting and timing attacks
🧯 DoS Opportunity	/profile and /trace can max out CPU usage
🧱 Misconfiguration	Indicates insecure transition from staging/dev to production
🔐 Recommended Remediation
✅ Immediate Fix

// Remove this from your code
import _ "net/http/pprof"

✅ Restrict Access

    Bind service only to 127.0.0.1

    Block external access via firewall or WAF

    Add authentication (e.g., Basic Auth) for internal ops access

✅ Hardening Tips

    Use Go build tags to restrict pprof in production

    Monitor access logs to /debug/pprof/*

    Enable alerting for anomalous profiler usage

🧩 References

    CVE-2019-11248 – NVD

    Go Docs – net/http/pprof

    OWASP – A6: Security Misconfiguration