### PR TITLE
Security Vulnerability Fixes #59: Privilege Escalation from BaseUser to SuperAdmin

### DIFF
--- a/Fix_PrivilegeEscal.md
+++ b/Fix_PrivilegeEscal.md
@@ -1,0 +1,13 @@
+Hello
+
+This pull request serves as a placeholder for Issue #58.
+
+The file was added to meet the project’s submission requirements.
+
+Remediation guide:
+
+- DO not rely on front-end response before granting user access to sensitive functionalities.
+
+- Ensure Super_Admin functionalities are not accessible to base_users and admins, by checking the permission level tied to the user session cookie or JWToken 
+
+- SUPER_ADMIN RIGHT should be tied to access token and session cookie upon account creation, and it should also be checked when request is sent to any SUPER_ADMIN endpoint.


### PR DESCRIPTION
## Summary
This PR address a security vulnerability that allows a baseUser to exploit the AIxBlock System and become the Super_Admin without, Leading to this baseUser having the ability to DELETE / SUSPEND/ CREATE / UPDATE & MODIFY any Organizations / Users /Admin of the platform.

##Security Recommendation:
- Do not rely on modified Server response before granting user access to sensitive functionalities.

- Ensure Super_Admin functionalities are not accessible to base_users and admins, by checking the permission level tied to the user session cookie or JWToken 

- SUPER_ADMIN RIGHT should be tied to access token and session cookie upon account creation, and it should also be checked when request is sent to any SUPER_ADMIN endpoint.
