### PR TITLE
Placeholder PR for Issue #116 – Exposure of Internal Infrastructure Data

### DIFF
--- a/placeholder-116.md
+++ b/placeholder-116.md
@@ -1,0 +1,5 @@
+This pull request is a placeholder for issue #116 regarding internal infrastructure metadata exposure via the `https://app.aixblock.io/api/settings/installation-service/` endpoint.
+
+The endpoint is accessible by normal authenticated users and leaks sensitive information such as Docker image names, registry URLs, environment types, and service versions.
+
+Since the bug reporting policy requires a pull request from a forked branch, this file serves as proof of submission. Looking forward to maintainers’ review. Thank you.

--- a/reports/account-deletion-idor-placeholder.md
+++ b/reports/account-deletion-idor-placeholder.md
@@ -1,0 +1,6 @@
+This pull request serves as a placeholder for the account deletion vulnerability reported in Issue #58, where any authenticated user can delete another user’s account by modifying the user ID in the /api/users/{user_id} endpoint.
+
+This commit adds a minimal placeholder to fulfill the bug submission requirements.
+
+Awaiting further instructions from the maintainers. Thank you.
+

--- a/reports/internal-metadata-exposure.md
+++ b/reports/internal-metadata-exposure.md
@@ -1,0 +1,7 @@
+This pull request is a placeholder related to the infrastructure metadata exposure issue I reported in issue #116.
+
+The endpoint `https://app.aixblock.io/api/settings/installation-service/` reveals internal configuration data such as Docker image names, environment types, registry URLs, and version info — all of which should ideally be restricted to internal or admin roles.
+
+This placeholder commit is made from my fork as part of the official submission requirements.
+
+Looking forward to any feedback or next steps. Thank you!


### PR DESCRIPTION
This pull request is submitted in reference to Issue #116.

The identified vulnerability relates to the `https://app.aixblock.io/api/settings/installation-service/` endpoint, which reveals internal infrastructure details such as Docker image names, registry URLs, service versions, and environment types. These details are accessible to any authenticated user, which could pose a security risk.

This placeholder file is created as part of the disclosure process from a forked branch, in line with the program’s reporting requirements. I look forward to the maintainers' review and feedback. Thank you.
