### PR TITLE
Fix for Issue #161 – Unauthorized Avatar Access and IDOR

### DIFF
--- a/avatar-leak-idor.md
+++ b/avatar-leak-idor.md
@@ -1,0 +1,64 @@
+This pull request corresponds to the vulnerability described in Issue #161[https://github.com/AIxBlock-2023/awesome-ai-dev-platform-opensource/issues/161] – Unauthorized Access to Avatar Images & IDOR via User Profile API.
+
+The application suffers from two related access control issues:
+
+**Public Avatar Access**
+
+User avatars are stored in the /data/avatars/ directory with predictable filenames. These files are accessible without authentication, allowing anyone with the filename (even after the avatar is replaced) to view them directly.
+
+**IDOR via /api/user/{id}**
+
+This endpoint returns limited profile data (ID, name, email, avatar filename) for any user ID. It requires authentication but allows cross-user access, enabling enumeration of avatar filenames. When combined with public access to avatar URLs, this creates an IDOR and privacy leak.
+
+**Proposed Code Fix**
+
+**1. Restrict Access to Avatar Files**
+
+Serve avatar images via an authenticated view that checks ownership or admin privileges
+
+```
+# views.py
+from django.contrib.auth.decorators import login_required
+from django.http import FileResponse, HttpResponseForbidden
+from django.shortcuts import get_object_or_404
+from myapp.models import User
+
+@login_required
+def get_avatar(request, user_id):
+    target_user = get_object_or_404(User, id=user_id)
+    
+    if request.user != target_user and not request.user.is_staff:
+        return HttpResponseForbidden("Unauthorized access.")
+    
+    avatar_path = target_user.profile.avatar.path
+    return FileResponse(open(avatar_path, 'rb'), content_type="image/jpeg")
+```
+
+**2. Remove Avatar Field from Cross-User /api/user/{id}**
+
+Only return the avatar field when the authenticated user is requesting their own data:
+
+```
+# serializers.py
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['id', 'first_name', 'last_name', 'username']  # No avatar by default
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        request = self.context.get('request')
+        
+        if request.user == instance or request.user.is_staff:
+            data['avatar'] = instance.profile.avatar.url
+        
+        return data
+```
+
+These changes ensure that:
+
+  - Avatar files cannot be accessed directly without authentication.
+
+  - /api/user/{id} no longer leaks avatar filenames unless authorized.
+
+  - The app enforces proper boundaries between users to protect profile images.

--- a/reports/account-deletion-idor-placeholder.md
+++ b/reports/account-deletion-idor-placeholder.md
@@ -1,0 +1,6 @@
+This pull request serves as a placeholder for the account deletion vulnerability reported in Issue #58, where any authenticated user can delete another user’s account by modifying the user ID in the /api/users/{user_id} endpoint.
+
+This commit adds a minimal placeholder to fulfill the bug submission requirements.
+
+Awaiting further instructions from the maintainers. Thank you.
+

--- a/reports/internal-metadata-exposure.md
+++ b/reports/internal-metadata-exposure.md
@@ -1,0 +1,7 @@
+This pull request is a placeholder related to the infrastructure metadata exposure issue I reported in issue #116.
+
+The endpoint `https://app.aixblock.io/api/settings/installation-service/` reveals internal configuration data such as Docker image names, environment types, registry URLs, and version info — all of which should ideally be restricted to internal or admin roles.
+
+This placeholder commit is made from my fork as part of the official submission requirements.
+
+Looking forward to any feedback or next steps. Thank you!


### PR DESCRIPTION
Fix for Issue #161 – Unauthorized Avatar Access and IDOR in Profile API

- User-uploaded avatars are publicly accessible via predictable static URLs under /data/avatars/

- The /api/user/{id} endpoint allows authenticated users to enumerate avatar filenames of other users