### PR TITLE
Create Fix-CAA-Record

### DIFF
--- a/Fix-CAA-Record
+++ b/Fix-CAA-Record
@@ -1,0 +1,4 @@
+Suggested DNS records:
+  aixblock.io. IN CAA 0 issue "letsencrypt.org"
+  aixblock.io. IN CAA 0 issuewild ";"
+  aixblock.io. IN CAA 0 iodef "mailto:security@aixblock.io"


### PR DESCRIPTION
Suggested DNS records:
  aixblock.io. IN CAA 0 issue "letsencrypt.org"
  aixblock.io. IN CAA 0 issuewild ";"
  aixblock.io. IN CAA 0 iodef "mailto:security@aixblock.io"
  



Updating CAA for Let’s Encrypt
If you want to allow only Let’s Encrypt to issue certificates:
1.  Log into your DNS provider (e.g., Cloudflare).
2.  Go to DNS > Records > Add Record.
3.  Set:
	•  Type: CAA
	•  Name: @ (root domain)
	•  Flag: 0
	•  Tag: issue
	•  Value: letsencrypt.org
4.  Add another record for iodef:
	•  Type: CAA
	•  Name: @
	•  Flag: 0
	•  Tag: iodef
	•  Value: mailto:admin@yourdomain.com
5.  Save and verify using dig CAA yourdomain.com or a lookup tool.

