### PR TITLE
Fix: Redirect unauthenticated users from AccountInfo page

### DIFF
--- a/frontend/src/pages/AccountSetting/AccountInfo/AccountInfo.tsx
+++ b/frontend/src/pages/AccountSetting/AccountInfo/AccountInfo.tsx
@@ -22,6 +22,14 @@ const AccountSettingContent = ({ user }: { user: TUserModel }) => {
   const auth = useAuth();
   const [isOpenModalConfirm, setIsOpenModalConfirm] = useState(false);
 
+    useEffect(() => {
+    if (!auth.isAuthenticated) {
+      setUserData(null);
+      resetToken();
+      navigate("/login");
+    }
+  }, [auth.isAuthenticated, navigate, resetToken]);
+
   const hostname = useMemo(() => {
     let h = window.APP_SETTINGS.hostname;
 


### PR DESCRIPTION
This PR fixes issue #193. 

- Redirects unauthenticated users from the AccountInfo page to the login page.
- Prevents unauthorized profile info changes after logout.

Fixes #193
